### PR TITLE
Db ip bug and gap typo

### DIFF
--- a/database/attempt-01.sql
+++ b/database/attempt-01.sql
@@ -41,7 +41,7 @@ CREATE TABLE Server (
     ip_address BIGINT UNSIGNED,
     ip_version ENUM('IPv4', 'IPv6'),
     location_id INT UNSIGNED NOT NULL,
-    CHECK (ip_address > 4294967295 OR ip_version='IPv4'),
+    CHECK (ip_address < 4294967296 OR ip_version='IPv6'),
     UNIQUE (ip_address, ip_version),
     FOREIGN KEY (location_id) REFERENCES Location(id)
 );

--- a/database/attempt-01.sql
+++ b/database/attempt-01.sql
@@ -75,7 +75,7 @@ CREATE TABLE Inv_Item (
     dept VARCHAR(255),
     space VARCHAR(255),
     date_last_ordered DATE,
-    purchase_price DECIMAL(13, 4), -- GAP guideline
+    purchase_price DECIMAL(13, 4), -- GAAP guideline
     warranty_expires DATE,
     item_condition VARCHAR(255), -- larger? enum?
     quantity INT UNSIGNED,


### PR DESCRIPTION
Typo: Generally Accepted Accounting Principles for monetary values previously referenced as GAP, not GAAP

IP Bug: IP values can be (IPv6 && x>2^32-1) || (IPv6 && x<2^32-1) || (IPv4 && x<2^32-1) but NOT (IPv4 && x>2^23-1). Old code allowed for (IPv4 && x<2^32-1) || (IPv4 && x>2^32-1) || (IPv6 && x>2^32-1) but NOT (IPv6 && x<2^32-1). Logic change now makes it correct, allowing for any IPv6 or IPv4 conditioned on x<2^32-1.